### PR TITLE
fix: root package with different rules as subpackages

### DIFF
--- a/validator/tests/allowed/allow-root-package-restrict-same-subpackage/config.yaml
+++ b/validator/tests/allowed/allow-root-package-restrict-same-subpackage/config.yaml
@@ -1,0 +1,15 @@
+imports-checks:
+  - folder: "internal/systems/$systemName"
+    subpackages: true
+    rules:
+      - prefix: "github.com/quantumcycle/go-import-checks/validator/tests/allowed/allow-root-package-restrict-same-subpackage/"
+        allow:
+          - "internal/systems/$systemName/**"
+          - "internal/systems/!$systemName/api"
+
+  - folder: "internal/systems"
+    subpackages: false
+    rules:
+      - prefix: "github.com/quantumcycle/go-import-checks/validator/tests/allowed/allow-root-package-restrict-same-subpackage/"
+        allow:
+          - "internal/systems/*/api"

--- a/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/init.go
+++ b/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/init.go
@@ -1,0 +1,12 @@
+package systems
+
+import (
+	api1 "github.com/quantumcycle/go-import-checks/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system1/api"
+	api2 "github.com/quantumcycle/go-import-checks/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system2/api"
+)
+
+func SubsystemCall() {
+	// This is allowed because the root systems package is allowed to import any all the subpackages apis
+	api1.ApiFn()
+	api2.ApiFn()
+}

--- a/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system1/api/api.go
+++ b/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system1/api/api.go
@@ -1,0 +1,7 @@
+package api
+
+import "github.com/quantumcycle/go-import-checks/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system1/domain"
+
+func ApiFn() {
+	domain.DomainFn()
+}

--- a/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system1/domain/domain.go
+++ b/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system1/domain/domain.go
@@ -1,0 +1,3 @@
+package domain
+
+func DomainFn() {}

--- a/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system2/api/api.go
+++ b/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system2/api/api.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	d1 "github.com/quantumcycle/go-import-checks/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system1/domain"
+	d2 "github.com/quantumcycle/go-import-checks/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system2/domain"
+)
+
+func ApiFn() {
+	d1.DomainFn()
+	d2.DomainFn()
+}

--- a/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system2/domain/domain.go
+++ b/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system2/domain/domain.go
@@ -1,0 +1,3 @@
+package domain
+
+func DomainFn() {}

--- a/validator/tests/allowed/restrict-same-subpackage/internal/systems/init.go
+++ b/validator/tests/allowed/restrict-same-subpackage/internal/systems/init.go
@@ -1,0 +1,7 @@
+package systems
+
+import "github.com/quantumcycle/go-import-checks/validator/tests/allowed/restrict-same-subpackage/internal/systems/system2/api"
+
+func SubsystemCall() {
+	api.ApiFn()
+}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -24,7 +24,10 @@ type Check struct {
 }
 
 func (chk Check) isApplicable(path string) bool {
-	pathParts := strings.Split(path, "/")
+	//ignore the filename, since we only care about package name in golang, not filenames
+	dir, _ := filepath.Split(path)
+	dir = strings.TrimSuffix(dir, "/")
+	pathParts := strings.Split(dir, "/")
 	chkParts := strings.Split(chk.Folder, "/")
 	for i, chkItem := range chkParts {
 		if i >= len(pathParts) {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -87,6 +87,17 @@ func TestAllowSameSubPackage(t *testing.T) {
 	})
 }
 
+func TestAllowRootCallSubpackages(t *testing.T) {
+	assertValidation(t, "tests/allowed/allow-root-package-restrict-same-subpackage", []ValidationError{
+		{
+			Path:       "internal/systems/system2/api/api.go",
+			Reason:     ReasonNotAllow,
+			ImportPath: "github.com/quantumcycle/go-import-checks/validator/tests/allowed/allow-root-package-restrict-same-subpackage/internal/systems/system1/domain",
+		},
+		//no errors on init.go in the systems package. we want that since it should not be covered by the existing rule
+	})
+}
+
 func TestAllowWildcardSubpackage(t *testing.T) {
 	assertValidation(t, "tests/allowed/restrict-wildcard-subpackage", []ValidationError{
 		{


### PR DESCRIPTION
Ignore the filename while applying rules because it prevent rules for a root folder different from the subfolders.