### PR TITLE
log error when yaml read fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 
 			cfg, err := readYamlCfg(c.String("config"))
 			if err != nil {
-				log.Fatalf("Cannot read yaml config file [%s]", c.String("config"))
+				log.Fatalf("Cannot read yaml config file [%s]: %s", c.String("config"), err)
 			}
 
 			validateImports(cfg, pathToCheck, c.Bool("debug"))


### PR DESCRIPTION
without logging the error, it is hard to understand why the yaml file was not loaded- it could be due to file reading or yaml parsing